### PR TITLE
otelcol-contrib.rb: use version field to make "brew upgrade" work

### DIFF
--- a/otelcol-contrib.rb
+++ b/otelcol-contrib.rb
@@ -2,6 +2,7 @@ class OtelcolContrib < Formula
   desc "OpenTelemetry Collector (binary contrib distribution)"
   homepage "https://opentelemetry.io/docs/collector/"
   license "Apache-2.0"
+  version "0.129.1"
 
   if Hardware::CPU.intel?
     url "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.129.1/otelcol-contrib_0.129.1_darwin_amd64.tar.gz"


### PR DESCRIPTION
Otherwise we get:

```
% brew update && brew upgrade otelcol-contrib
==> Updating Homebrew...
Already up-to-date.
Warning: cirruslabs/cli/otelcol-contrib 64 already installed
```