### PR TITLE
Remove deprecated depends_on :macos declarations

### DIFF
--- a/gitlab-tart-executor.rb
+++ b/gitlab-tart-executor.rb
@@ -8,7 +8,6 @@ class GitlabTartExecutor < Formula
   version "1.28.0"
 
   depends_on "cirruslabs/cli/tart"
-  depends_on :macos
 
   if Hardware::CPU.arm?
     url "https://github.com/cirruslabs/gitlab-tart-executor/releases/download/1.28.0/gitlab-tart-executor-darwin-arm64.tar.gz"

--- a/mtell.rb
+++ b/mtell.rb
@@ -6,7 +6,6 @@ class Mtell < Formula
   desc "CLI to tell a machine to do something over VNC"
   homepage "https://github.com/cirruslabs/mtell"
   version "0.4.2"
-  depends_on :macos
 
   if Hardware::CPU.intel?
     url "https://github.com/cirruslabs/mtell/releases/download/0.4.2/mtell-darwin-amd64.tar.gz"

--- a/softnet.rb
+++ b/softnet.rb
@@ -6,7 +6,7 @@ class Softnet < Formula
   desc "Software networking with isolation for Tart"
   homepage "https://github.com/cirruslabs/softnet"
   version "0.19.0"
-  depends_on :macos
+
 
   url "https://github.com/cirruslabs/softnet/releases/download/0.19.0/softnet.tar.gz"
   sha256 "1612e1296834aae0b6389650c7c5190add1ee8d71474e328691e67679ecda53c"

--- a/tart.rb
+++ b/tart.rb
@@ -9,7 +9,6 @@ class Tart < Formula
   license "Fair Source"
 
   depends_on "cirruslabs/cli/softnet"
-  depends_on :macos
 
   url "https://github.com/cirruslabs/tart/releases/download/2.32.1/tart.tar.gz"
   sha256 "8554ab4f7fc12afe52f9b7e3093a935673cbac737a83973d2db7a0683c814529"


### PR DESCRIPTION
    sed -i '' '/^[[:space:]]*depends_on :macos$/d' *.rb Casks/*.rb

Homebrew emits deprecation warnings because these formulae contain
both `depends_on :macos` and version-specific macOS constraints such as `depends_on :macos => :ventura`
The unconditional dependency is redundant and triggers warnings during normal brew operations.
This change removes the deprecated declarations while preserving the existing minimum macOS version requirements.