### PR TITLE
Remove deprecated macos deps

### DIFF
--- a/gitlab-tart-executor.rb
+++ b/gitlab-tart-executor.rb
@@ -8,7 +8,6 @@ class GitlabTartExecutor < Formula
   version "1.28.0"
 
   depends_on "cirruslabs/cli/tart"
-  depends_on :macos
 
   if Hardware::CPU.arm?
     url "https://github.com/cirruslabs/gitlab-tart-executor/releases/download/1.28.0/gitlab-tart-executor-darwin-arm64.tar.gz"

--- a/gitlab-tart-executor.rb
+++ b/gitlab-tart-executor.rb
@@ -8,16 +8,16 @@ class GitlabTartExecutor < Formula
   version "1.28.0"
 
   depends_on "cirruslabs/cli/tart"
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/cirruslabs/gitlab-tart-executor/releases/download/1.28.0/gitlab-tart-executor-darwin-arm64.tar.gz"
+      sha256 "5b7dea840cdbabcbf3806da1d95d58c3b125dc6385b9eace86fb746c52796103"
 
-  if Hardware::CPU.arm?
-    url "https://github.com/cirruslabs/gitlab-tart-executor/releases/download/1.28.0/gitlab-tart-executor-darwin-arm64.tar.gz"
-    sha256 "5b7dea840cdbabcbf3806da1d95d58c3b125dc6385b9eace86fb746c52796103"
-
-    define_method(:install) do
-      bin.install "gitlab-tart-executor"
+      define_method(:install) do
+        bin.install "gitlab-tart-executor"
+      end
     end
   end
-
   def caveats
     <<~EOS
       See the Github repository for more information

--- a/mtell.rb
+++ b/mtell.rb
@@ -6,7 +6,6 @@ class Mtell < Formula
   desc "CLI to tell a machine to do something over VNC"
   homepage "https://github.com/cirruslabs/mtell"
   version "0.4.2"
-  depends_on :macos
 
   if Hardware::CPU.intel?
     url "https://github.com/cirruslabs/mtell/releases/download/0.4.2/mtell-darwin-amd64.tar.gz"

--- a/mtell.rb
+++ b/mtell.rb
@@ -7,25 +7,27 @@ class Mtell < Formula
   homepage "https://github.com/cirruslabs/mtell"
   version "0.4.2"
 
-  if Hardware::CPU.intel?
-    url "https://github.com/cirruslabs/mtell/releases/download/0.4.2/mtell-darwin-amd64.tar.gz"
-    sha256 "5b378c382285a9e7bdc9ac105b4e88a0c91067cfe57671979dd9c454aaaa61da"
+  on_macos do
+    if Hardware::CPU.intel?
+      url "https://github.com/cirruslabs/mtell/releases/download/0.4.2/mtell-darwin-amd64.tar.gz"
+      sha256 "5b378c382285a9e7bdc9ac105b4e88a0c91067cfe57671979dd9c454aaaa61da"
 
-    define_method(:install) do
-      bin.install "mtell"
-      generate_completions_from_executable(bin/"mtell", "completion")
+      define_method(:install) do
+        bin.install "mtell"
+        generate_completions_from_executable(bin/"mtell", "completion")
+      end
+    end
+
+    if Hardware::CPU.arm?
+      url "https://github.com/cirruslabs/mtell/releases/download/0.4.2/mtell-darwin-arm64.tar.gz"
+      sha256 "00bb54471369c23b75e8aa249b1f7c4c85edc2ae4eea8e01f2616f560e7aa01f"
+
+      define_method(:install) do
+        bin.install "mtell"
+        generate_completions_from_executable(bin/"mtell", "completion")
+      end
     end
   end
-  if Hardware::CPU.arm?
-    url "https://github.com/cirruslabs/mtell/releases/download/0.4.2/mtell-darwin-arm64.tar.gz"
-    sha256 "00bb54471369c23b75e8aa249b1f7c4c85edc2ae4eea8e01f2616f560e7aa01f"
-
-    define_method(:install) do
-      bin.install "mtell"
-      generate_completions_from_executable(bin/"mtell", "completion")
-    end
-  end
-
   def caveats
     <<~EOS
       See the Github repository for more information

--- a/softnet.rb
+++ b/softnet.rb
@@ -6,7 +6,7 @@ class Softnet < Formula
   desc "Software networking with isolation for Tart"
   homepage "https://github.com/cirruslabs/softnet"
   version "0.19.0"
-  depends_on :macos
+
 
   url "https://github.com/cirruslabs/softnet/releases/download/0.19.0/softnet.tar.gz"
   sha256 "1612e1296834aae0b6389650c7c5190add1ee8d71474e328691e67679ecda53c"

--- a/softnet.rb
+++ b/softnet.rb
@@ -6,17 +6,14 @@ class Softnet < Formula
   desc "Software networking with isolation for Tart"
   homepage "https://github.com/cirruslabs/softnet"
   version "0.19.0"
-
-
-  url "https://github.com/cirruslabs/softnet/releases/download/0.19.0/softnet.tar.gz"
-  sha256 "1612e1296834aae0b6389650c7c5190add1ee8d71474e328691e67679ecda53c"
-
-  define_method(:install) do
-    bin.install "softnet"
+  on_macos do
+    url "https://github.com/cirruslabs/softnet/releases/download/0.19.0/softnet.tar.gz"
+    sha256 "1612e1296834aae0b6389650c7c5190add1ee8d71474e328691e67679ecda53c"
+    depends_on macos: :sequoia
+    def install
+      bin.install "softnet"
+    end
   end
-
-  depends_on :macos => :sequoia
-
   def caveats
     <<~EOS
       See the Github repository for more information

--- a/tart.rb
+++ b/tart.rb
@@ -5,21 +5,26 @@
 class Tart < Formula
   desc "Run macOS and Linux VMs on Apple Hardware"
   homepage "https://github.com/cirruslabs/tart"
-  url "https://github.com/cirruslabs/tart/releases/download/2.32.1/tart.tar.gz"
   version "2.32.1"
-  sha256 "8554ab4f7fc12afe52f9b7e3093a935673cbac737a83973d2db7a0683c814529"
   license "Fair Source"
 
-  depends_on "cirruslabs/cli/softnet"
+  on_macos do
+    url "https://github.com/cirruslabs/tart/releases/download/2.32.1/tart.tar.gz"
+    sha256 "8554ab4f7fc12afe52f9b7e3093a935673cbac737a83973d2db7a0683c814529"
+    depends_on "cirruslabs/cli/softnet"
+    depends_on macos: :ventura
+    
+    def install
+      libexec.install Dir["*"]
+      bin.write_exec_script "#{libexec}/tart.app/Contents/MacOS/tart"
+    end
 
-  define_method(:install) do
-    libexec.install Dir["*"]
-    bin.write_exec_script "#{libexec}/tart.app/Contents/MacOS/tart"
-  end
-
-  depends_on macos: :ventura
-  def post_install
-    generate_completions_from_executable(libexec/"tart.app/Contents/MacOS/tart", "--generate-completion-script")
+    def post_install
+      generate_completions_from_executable(
+        libexec/"tart.app/Contents/MacOS/tart",
+        "--generate-completion-script"
+      )
+    end
   end
 
   def caveats

--- a/tart.rb
+++ b/tart.rb
@@ -5,20 +5,19 @@
 class Tart < Formula
   desc "Run macOS and Linux VMs on Apple Hardware"
   homepage "https://github.com/cirruslabs/tart"
+  url "https://github.com/cirruslabs/tart/releases/download/2.32.1/tart.tar.gz"
   version "2.32.1"
+  sha256 "8554ab4f7fc12afe52f9b7e3093a935673cbac737a83973d2db7a0683c814529"
   license "Fair Source"
 
   depends_on "cirruslabs/cli/softnet"
-
-  url "https://github.com/cirruslabs/tart/releases/download/2.32.1/tart.tar.gz"
-  sha256 "8554ab4f7fc12afe52f9b7e3093a935673cbac737a83973d2db7a0683c814529"
 
   define_method(:install) do
     libexec.install Dir["*"]
     bin.write_exec_script "#{libexec}/tart.app/Contents/MacOS/tart"
   end
 
-  depends_on :macos => :ventura
+  depends_on macos: :ventura
   def post_install
     generate_completions_from_executable(libexec/"tart.app/Contents/MacOS/tart", "--generate-completion-script")
   end

--- a/tart.rb
+++ b/tart.rb
@@ -9,7 +9,6 @@ class Tart < Formula
   license "Fair Source"
 
   depends_on "cirruslabs/cli/softnet"
-  depends_on :macos
 
   url "https://github.com/cirruslabs/tart/releases/download/2.32.1/tart.tar.gz"
   sha256 "8554ab4f7fc12afe52f9b7e3093a935673cbac737a83973d2db7a0683c814529"


### PR DESCRIPTION
Replace deprecated `depends_on :macos` declarations.

`mtell.rb` and `gitlab-tart-executor.rb` relied on
`depends_on :macos` to prevent Linuxbrew from selecting
Darwin artifacts on matching CPU architectures.

These formulae are now explicitly wrapped in `on_macos`
blocks while preserving existing behavior.

`tart.rb` was updated to current Homebrew syntax for
macOS version constraints.